### PR TITLE
categorise variants draft

### DIFF
--- a/falcon/categorise.py
+++ b/falcon/categorise.py
@@ -22,15 +22,15 @@ def categorise(xml_collation_result):
         
             # if <rdg>s have same @lemma, @pos and @msd > diffGraph
             if (len(set(lemmas)) == 1) and (len(set(poss)) == 1) and (len(set(msds)) == 1):
-                variationCategory = "diffGraph"
+                variationCategory = "graphematic"
             # if <rdg>s have same @lemma, @pos, but different @msd > diffMorph
             elif (len(set(lemmas)) == 1) and (len(set(poss)) == 1):
-                variationCategory = "diffMorph"
+                variationCategory = "flexional"
             # if <rdg>s have same @lemma, but different @pos and @msd > diffPos
             elif (len(set(lemmas)) == 1):
-                variationCategory = "diffPos"
+                variationCategory = "morphosyntactic"
             else:
-                variationCategory = "diffLemma"
+                variationCategory = "lexical"
 
             # add @ana to <app> to categorize the variation
             element.set("ana", variationCategory)

--- a/falcon/categorise.py
+++ b/falcon/categorise.py
@@ -1,0 +1,40 @@
+from lxml import etree
+
+with open("out.xml", "r", encoding="utf-8") as inFile:
+    root = etree.parse(inFile)
+
+#for each <app>
+for element in root.iter("app"):
+
+    # create a list of <rdg>s content
+    rdgs = [rdg.text for rdg in element.iter("rdg")] 
+    
+    # if <rdg>s have different contents, there is a variation
+    # to check if they are equal, transform the list to set, which removes duplicates
+    if (len(rdgs)> 1) and (len(set(rdgs)) != 1):
+    
+        # create lists of @lemmas, @pos and @msd
+        lemmas = [rdg.get("lemma") for rdg in element.iter("rdg")]
+        poss = [rdg.get("pos") for rdg in element.iter("rdg")]
+        msds = [rdg.get("msd") for rdg in element.iter("rdg")]
+    
+        # if <rdg>s have same @lemma, @pos and @msd > diffGraph
+        if (len(set(lemmas)) == 1) and (len(set(poss)) == 1) and (len(set(msds)) == 1):
+            variationCategory = "diffGraph"
+        # if <rdg>s have same @lemma, @pos, but different @msd > diffMorph
+        elif (len(set(lemmas)) == 1) and (len(set(poss)) == 1):
+            variationCategory = "diffMorph"
+        # if <rdg>s have same @lemma, but different @pos and @msd > diffPos
+        elif (len(set(lemmas)) == 1):
+            variationCategory = "diffPos"
+        else:
+            variationCategory = "diffLemma"
+
+        # add @ana to <app> to categorize the variation
+        element.set("ana", variationCategory)
+
+with open("outout.xml", "w", encoding="utf-8") as outFile:
+    outFile.write(str(etree.tostring(root, pretty_print=True, encoding="unicode")))
+
+
+

--- a/falcon/categorise.py
+++ b/falcon/categorise.py
@@ -1,40 +1,42 @@
 from lxml import etree
 
-with open("out.xml", "r", encoding="utf-8") as inFile:
-    root = etree.parse(inFile)
+def categorise(xml_collation_result):
 
-#for each <app>
-for element in root.iter("app"):
+    with open(xml_collation_result, "r", encoding="utf-8") as inFile:
+        root = etree.parse(inFile)
+        
+    #for each <app>
+    for element in root.iter("app"):
 
-    # create a list of <rdg>s content
-    rdgs = [rdg.text for rdg in element.iter("rdg")] 
-    
-    # if <rdg>s have different contents, there is a variation
-    # to check if they are equal, transform the list to set, which removes duplicates
-    if (len(rdgs)> 1) and (len(set(rdgs)) != 1):
-    
-        # create lists of @lemmas, @pos and @msd
-        lemmas = [rdg.get("lemma") for rdg in element.iter("rdg")]
-        poss = [rdg.get("pos") for rdg in element.iter("rdg")]
-        msds = [rdg.get("msd") for rdg in element.iter("rdg")]
-    
-        # if <rdg>s have same @lemma, @pos and @msd > diffGraph
-        if (len(set(lemmas)) == 1) and (len(set(poss)) == 1) and (len(set(msds)) == 1):
-            variationCategory = "diffGraph"
-        # if <rdg>s have same @lemma, @pos, but different @msd > diffMorph
-        elif (len(set(lemmas)) == 1) and (len(set(poss)) == 1):
-            variationCategory = "diffMorph"
-        # if <rdg>s have same @lemma, but different @pos and @msd > diffPos
-        elif (len(set(lemmas)) == 1):
-            variationCategory = "diffPos"
-        else:
-            variationCategory = "diffLemma"
+        # create a list of <rdg>s content
+        rdgs = [rdg.text for rdg in element.iter("rdg")] 
+        
+        # if <rdg>s have different contents, there is a variation
+        # to check if they are equal, transform the list to set, which removes duplicates
+        if (len(rdgs)> 1) and (len(set(rdgs)) != 1):
+        
+            # create lists of @lemmas, @pos and @msd
+            lemmas = [rdg.get("lemma") for rdg in element.iter("rdg")]
+            poss = [rdg.get("pos") for rdg in element.iter("rdg")]
+            msds = [rdg.get("msd") for rdg in element.iter("rdg")]
+        
+            # if <rdg>s have same @lemma, @pos and @msd > diffGraph
+            if (len(set(lemmas)) == 1) and (len(set(poss)) == 1) and (len(set(msds)) == 1):
+                variationCategory = "diffGraph"
+            # if <rdg>s have same @lemma, @pos, but different @msd > diffMorph
+            elif (len(set(lemmas)) == 1) and (len(set(poss)) == 1):
+                variationCategory = "diffMorph"
+            # if <rdg>s have same @lemma, but different @pos and @msd > diffPos
+            elif (len(set(lemmas)) == 1):
+                variationCategory = "diffPos"
+            else:
+                variationCategory = "diffLemma"
 
-        # add @ana to <app> to categorize the variation
-        element.set("ana", variationCategory)
+            # add @ana to <app> to categorize the variation
+            element.set("ana", variationCategory)
 
-with open("outout.xml", "w", encoding="utf-8") as outFile:
-    outFile.write(str(etree.tostring(root, pretty_print=True, encoding="unicode")))
+    categorisedOutput = str(etree.tostring(root, pretty_print=True, encoding="unicode"))
 
+    return categorisedOutput
 
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
+from ast import arg
 import falcon.collation as coll
 import falcon.lemmatise as lemm
+import falcon.categorise as categ
 import falcon.simple as simple
 import collatex
 import os
@@ -18,6 +20,7 @@ if __name__ == "__main__":
     parser.add_argument('--engine', action='store', choices=['pie', 'freeling'], default='pie', help="lemmatisation engine to use")
     parser.add_argument('--output_dir', action='store', default='out',
                         help="name of the output directory (default 'out')")
+    parser.add_argument('--categorise', action='store_true', help="categorise the variants resulted from the collation")
     args = parser.parse_args()
 
     # create output dir
@@ -57,3 +60,21 @@ if __name__ == "__main__":
 
         with open(args.output_dir + "/coll" + "/out.table", 'w') as f:
             print(table, file=f)
+
+    if args.categorise:
+
+        if args.collate is not True:
+            # use the specified folder path which should include collation results in XML (<app>, <rdg>)
+            xml_to_be_categorised = args.folder_path
+        else:
+            # use the collation results from previous step
+            xml_to_be_categorised = args.output_dir + "/coll/out.xml"
+
+        # assign a category to each <app> containing variant <rdg>s
+        categ_xml_output = categ.categorise(xml_to_be_categorised)
+
+        os.makedirs(args.output_dir + "/categ", exist_ok=True)
+
+        with open(args.output_dir + "/categ/out.xml", "w", encoding="utf-8") as f:
+            print(categ_xml_output, file=f)
+

--- a/main.py
+++ b/main.py
@@ -64,8 +64,8 @@ if __name__ == "__main__":
     if args.categorise:
 
         if args.collate is not True:
-            # use the specified folder path which should include collation results in XML (<app>, <rdg>)
-            xml_to_be_categorised = args.folder_path
+            # use the specified folder path which should include collation results in XML (<app>, <rdg>) in a file 'out.xml'
+            xml_to_be_categorised = args.folder_path + "/out.xml"
         else:
             # use the collation results from previous step
             xml_to_be_categorised = args.output_dir + "/coll/out.xml"


### PR DESCRIPTION
Draft in python to categorise the variation sites in the collatex xml output (cf. #2)

Still to be integrated in the rest of the code structure. It should be possible to launch it alone (`python3 main.py <path> [--categorise]`) or in combination with the rest (`python3 main.py <path> [--lemmatise] [--collate] [--categorise]`).



