### PR TITLE
back to python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains scripts for a collation processing workflow and its eva
 
 ```bash
 # Recommended steps (use virtualenv)
-virtualenv env -p python3.8
+virtualenv env -p python3.7
 source env/bin/activate
 # end recommended steps
 


### PR DESCRIPTION
Pie-extended is only compatible with up to Python3.7 (see https://pypi.org/project/pie-extended/)
I tried ... and it gives an error when running in Python 3.8